### PR TITLE
Bugfix/total count and last page fix when externalized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ buildNumber.properties
 .gradle/
 gradle/
 *build/*
-/plugin/build/
+/build-plugin/build/
+/plugin-test/build/
 # ----------------------------------
 # App-specific
 # ----------------------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 0.0.4
 * CHANGED function signature of connectionProperty for use with externalized pagination
-* FIXED #2 Externalized Pagination in connectionProperty reports wrong totalCount and lastPage values
+* FIXED #2:  Externalized Pagination in connectionProperty reports wrong totalCount and lastPage values
 
 0.0.3
 * CHANGED function name of `paginate` function to `paginateInMemory`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.0.4
+* CHANGED function signature of connectionProperty for use with externalized pagination
+* FIXED #2 Externalized Pagination in connectionProperty reports wrong totalCount and lastPage values
+
 0.0.3
 * CHANGED function name of `paginate` function to `paginateInMemory`.
 * CHANGED function signature of `paginateInMemory` to no longer require toCursor-function.

--- a/README.md
+++ b/README.md
@@ -88,10 +88,13 @@ KGraphQL.schema {
     type<SomeType>() {
         Example.connectionProperty(
             this,
-            "exampleConnections", 
-            { parent: SomeType, first: Int?, after: Int? -> 
-                ExampleProvider.getPaginatedExamplesForParent(parent, first, after) 
-            }// :(SomeType, Int?, Type of the Identifier-annotated Property)->List<Example>
+            "exampleConnections",
+            // (SomeType)->Int
+            ExampleProvider::getTotalCount, 
+            // (SomeType, Type of the Identifier-annotated Property) -> Int
+            ExampleProvider::getCountAfterCursor, 
+            // :(SomeType, Int?, Type of the Identifier-annotated Property)->List<Example>
+            ExampleProvider::getPaginatedExamplesForParent 
         )
     }
     

--- a/build-plugin/src/main/kotlin/com/linkedplanet/plugin/graphqlplugin/Pagination.kt
+++ b/build-plugin/src/main/kotlin/com/linkedplanet/plugin/graphqlplugin/Pagination.kt
@@ -49,17 +49,14 @@ fun <T> paginateInMemory(
     edgeConstructor: (T, String) -> Edge<T>,
     connectionConstructor: (Int, List<Edge<T>>, PageInfo) -> Connection<T>
 ): Connection<T> {
-    val decodedAfter = after?.let {
-        decodeCursor(it) { it }
-    }
     val offset =
-        if (decodedAfter != null) results.dropWhile { decodedAfter != toCursor(it) }.drop(1)
+        if (after != null) results.dropWhile { after != toCursor(it) }.drop(1)
         else results
     val shortened =
         if (first != null) offset.take(first)
         else offset
     val edges = shortened.map { item ->
-        edgeConstructor(item, encodeCursor(item, toCursor))
+        edgeConstructor(item, toCursor(item))
     }
     return connectionConstructor(
         results.size,

--- a/build-plugin/src/main/kotlin/com/linkedplanet/plugin/graphqlplugin/Pagination.kt
+++ b/build-plugin/src/main/kotlin/com/linkedplanet/plugin/graphqlplugin/Pagination.kt
@@ -68,6 +68,27 @@ fun <T> paginateInMemory(
     )
 }
 
+/**
+ * Function that wraps externalized pagination for any list of 'Paginated'-annotated objects.
+ */
+fun <T> paginateExternal(
+    results: List<T>,
+    totalCount: Int,
+    countAfterOffset: Int,
+    toCursor: (T) -> String,
+    edgeConstructor: (T, String) -> Edge<T>,
+    connectionConstructor: (Int, List<Edge<T>>, PageInfo) -> Connection<T>
+): Connection<T> {
+    val edges = results.map { item ->
+        edgeConstructor(item, encodeCursor(item, toCursor))
+    }
+    return connectionConstructor(
+        totalCount,
+        edges,
+        PageInfo(edges.lastOrNull()?.cursor, countAfterOffset <= results.size)
+    )
+}
+
 fun <T> decodeCursor(cursor: String, fromCursor: (String)->T): T =
     fromCursor(Base64.getDecoder().decode(cursor).map { b -> b.toChar() }.joinToString())
 

--- a/build-plugin/src/main/kotlin/com/linkedplanet/plugin/graphqlplugin/ProcessPagination.kt
+++ b/build-plugin/src/main/kotlin/com/linkedplanet/plugin/graphqlplugin/ProcessPagination.kt
@@ -92,6 +92,17 @@ val Meta.processIdentifier: CliPlugin
                        |    ).fix()
                        |}
                        |
+                       |fun List<${clazz.name}>.paginateExternal(totalCount: Int, countAfterCursor: Int): $connName {
+                       |    return paginateExternal(
+                       |        this,
+                       |        totalCount,
+                       |        countAfterCursor,
+                       |        ${clazz.name}::toCursor,
+                       |        { n, c -> $edgeName(n, c) },
+                       |        { c, e, p -> $connName(c, e.map { it.fix() }, p) }
+                       |    ).fix()
+                       |}
+                       |
                        |fun <T: Any> ${clazz.name}.Companion.connectionProperty(
                        |                        typeDsl: TypeDSL<T>,
                        |                        propertyName: String, 
@@ -109,12 +120,14 @@ val Meta.processIdentifier: CliPlugin
                        |fun <T: Any> ${clazz.name}.Companion.connectionProperty(
                        |                        typeDsl: TypeDSL<T>,
                        |                        propertyName: String, 
+                       |                        totalCount: (T)->Int,
+                       |                        countAfterCursor: (T,${type}?)->Int,
                        |                        toResults: suspend (T,Int?,${type}?)->List<${clazz.name}>): Unit {
                        |    typeDsl.property<$connName>(propertyName) {
                        |        resolver { t, first: Int?, after: String? ->
-                       |            toResults(t, first, after?.let { ${clazz.name}.fromCursor(it) }).paginateInMemory(
-                       |                first,
-                       |                after
+                       |            toResults(t, first, after?.let { ${clazz.name}.fromCursor(it) }).paginateExternal(
+                       |                totalCount(t),
+                       |                countAfterCursor(t, after?.let { ${clazz.name}.fromCursor(it) })
                        |            ) 
                        |        }
                        |    }

--- a/plugin-test/src/main/kotlin/ut/Model.kt
+++ b/plugin-test/src/main/kotlin/ut/Model.kt
@@ -7,13 +7,17 @@ import com.linkedplanet.plugin.graphqlplugin.*
 data class TestProperty(
     @Identifier val uniqueId: Int,
     val someString: String
-) {companion object}
+) {
+    companion object
+}
 
 @Paginated
 data class TestQuery(
     @Identifier val uniqueId: Int,
     val someString: String
-) {companion object}
+) {
+    companion object
+}
 
 val schema = KGraphQL.schema {
     type<PageInfo>()
@@ -22,14 +26,17 @@ val schema = KGraphQL.schema {
     type<TestQuery>() {
         TestQuery.cursorProperty(this)
         TestProperty.connectionProperty(this, "propConnection") { _: TestQuery ->
-            listOf(TestProperty(0, "Property"))
+            listOf(
+                TestProperty(0, "Property1"),
+                TestProperty(1, "Property2")
+            )
         }
     }
 
     TestQuery.paginatedQuery(this, "allQueries", -1) { first: Int, after: Int ->
         listOf(
-            TestQuery(0,"Query 1"),
-            TestQuery(1,"Query 2"),
+            TestQuery(0, "Query 1"),
+            TestQuery(1, "Query 2"),
         ).filter { it.uniqueId > after }.take(first)
     }
 }

--- a/plugin-test/src/test/kotlin/ut/TestGeneration.kt
+++ b/plugin-test/src/test/kotlin/ut/TestGeneration.kt
@@ -12,10 +12,25 @@ class GenerationTest: StringSpec({
         result shouldNotContain "Query 2"
     }
 
+    "TestQuery should accept offset" {
+        val result = schema.execute("{allQueries(first:1, after: \"MA==\"){someString cursor}}")
+        result shouldNotContain "Query 1"
+        result shouldContain "Query 2"
+    }
+
     "TestProperty should have pagination" {
-        val result = schema.execute("{allQueries(first:2){someString propConnection(first:1) { edges { node {someString}} }}}")
+        val result = schema.execute("{allQueries(first:2){someString propConnection(first:1) { edges { cursor node {someString}} pageInfo { lastCursor } }}}")
         result shouldContain "Query 1"
         result shouldContain "Query 2"
-        result shouldContain "Property"
+        result shouldContain "Property1"
+        result shouldNotContain "Property2"
+    }
+
+    "TestProperty should accept offset" {
+        val result = schema.execute("{allQueries(first:2){someString propConnection(first:1, after: \"MA==\") { edges { node {someString}} }}}")
+        result shouldContain "Query 1"
+        result shouldContain "Query 2"
+        result shouldNotContain "Property1"
+        result shouldContain "Property2"
     }
 })


### PR DESCRIPTION
* CHANGED function signature of connectionProperty for use with externalized pagination
* FIXED #2:  Externalized Pagination in connectionProperty reports wrong totalCount and lastPage values
